### PR TITLE
Sync admin and stage via shared script

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -120,6 +120,10 @@
     document.getElementById('addOrbBtn').addEventListener('click', addOrbSmart);
     document.getElementById('saveOrbsBtn').addEventListener('click', saveOrbs);
     document.getElementById('loadOrbsBtn').addEventListener('click', loadOrbs);
+    // share any existing orbs with the stage on load
+    if (typeof sendOrbsToStage === 'function') {
+      sendOrbsToStage();
+    }
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "stream_orbs",
+  "version": "1.0.0",
+  "description": "Automated tests for orb sync",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/shared.js
+++ b/shared.js
@@ -4,10 +4,15 @@ const canvas = document.getElementById('bouncerCanvas');
 const ctx = canvas ? canvas.getContext('2d') : null;
 const orbSize = 64;
 const orbs = [];
+// expose orbs for other scripts and tests
+window.orbs = orbs;
 
 const channel = new BroadcastChannel('orb-sync');
+// expose channel for tests to shut down
+window.channel = channel;
+const isAdmin = window.location.href.includes('admin');
 
-if (window.location.href.includes('admin')) {
+if (isAdmin) {
   // Admin sends data when orbs are added or updated
   window.sendOrbsToStage = function () {
     const state = orbs.map(o => ({
@@ -21,6 +26,13 @@ if (window.location.href.includes('admin')) {
     }));
     channel.postMessage({ type: 'sync', data: state });
   };
+
+  // Respond to stage requests for data
+  channel.onmessage = (event) => {
+    if (event.data?.type === 'request-sync') {
+      window.sendOrbsToStage();
+    }
+  };
 } else {
   // Stage listens and syncs
   channel.onmessage = (event) => {
@@ -31,6 +43,9 @@ if (window.location.href.includes('admin')) {
       });
     }
   };
+
+  // Expose helper to request current orbs from any admin page
+  window.requestOrbSync = () => channel.postMessage({ type: 'request-sync' });
 }
 
 function updateCanvasBackground() {
@@ -53,15 +68,14 @@ function applyAspectRatio() {
 }
 
 function addOrb(src = '', entryType = 'drop', role = 'none', label = '', ringColor = '#ffffff', ringWidth = 4, roleIcon = '') {
-  if (!canvas) return;
   const orb = {
     img: new Image(),
-    x: Math.random() * (canvas.width - orbSize),
-    y: -orbSize,
+    x: 0,
+    y: 0,
     dx: 0,
     dy: 0,
-    vx: 2 + Math.random() * 2,
-    dir: Math.random() < 0.5 ? -1 : 1,
+    vx: 0,
+    dir: 1,
     isEntering: true,
     entryType,
     bounceCount: 0,
@@ -73,10 +87,153 @@ function addOrb(src = '', entryType = 'drop', role = 'none', label = '', ringCol
     moveTimer: 0,
     moveState: 'idle'
   };
+  if (canvas) {
+    orb.x = Math.random() * (canvas.width - orbSize);
+    orb.y = -orbSize;
+    orb.vx = 2 + Math.random() * 2;
+    orb.dir = Math.random() < 0.5 ? -1 : 1;
+  }
   orb.img.src = src;
   orbs.push(orb);
   if (typeof updateOrbList === 'function') updateOrbList();
-  if (typeof sendOrbsToStage === 'function') sendOrbsToStage();
+  if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage();
+}
+
+function addOrbSmart() {
+  const inputEl = document.getElementById('newOrbInput');
+  if (!inputEl) return;
+  const input = inputEl.value.trim();
+  const roleEl = document.getElementById('userRole');
+  const entryEl = document.getElementById('entryType');
+  const labelEl = document.getElementById('orbLabel');
+  const colorEl = document.getElementById('orbColor');
+  const widthEl = document.getElementById('orbThickness');
+  const iconEl = document.getElementById('roleIcon');
+  const sourceTypeEl = document.getElementById('sourceType');
+  const role = roleEl ? roleEl.value : 'none';
+  const entryType = entryEl ? entryEl.value : 'drop';
+  const label = labelEl ? labelEl.value.trim() : '';
+  const ringColor = colorEl ? colorEl.value : '#ffffff';
+  const ringWidth = widthEl ? parseInt(widthEl.value) : 4;
+  const roleIcon = iconEl ? iconEl.value.trim() : '';
+  const sourceType = sourceTypeEl ? sourceTypeEl.value : 'online';
+
+  if (sourceType === 'online') {
+    let finalUrl = '';
+    if (input.startsWith('http')) {
+      finalUrl = input;
+    } else if (input.startsWith('users_')) {
+      const parts = input.replace('.webp', '').split('_');
+      const userId = parts[1];
+      const hash = parts.slice(2).join('_') + '.webp';
+      finalUrl = `https://images.whatnot.com/fit-in/1920x0/filters:format(webp)/users%2F${userId}%2F${hash}`;
+    } else if (input.includes('/') && input.includes('.')) {
+      const [userId, hash] = input.split('/');
+      finalUrl = `https://images.whatnot.com/fit-in/1920x0/filters:format(webp)/users%2F${userId}%2F${hash}`;
+    }
+    if (finalUrl) {
+      addOrb(finalUrl, entryType, role, label, ringColor, ringWidth, roleIcon);
+      inputEl.value = '';
+    }
+  } else {
+    const fileInput = document.getElementById('fileInput');
+    if (!fileInput) return;
+    fileInput.click();
+    fileInput.onchange = function () {
+      const file = fileInput.files[0];
+      if (file) {
+        const localURL = URL.createObjectURL(file);
+        addOrb(localURL, entryType, role, label, ringColor, ringWidth, roleIcon);
+        fileInput.value = '';
+      }
+    };
+  }
+}
+
+function updateOrbList() {
+  const orbList = document.getElementById('orbList');
+  if (!orbList) return;
+  orbList.innerHTML = '';
+  orbs.forEach((orb, i) => {
+    const container = document.createElement('div');
+    container.className = 'orb-row';
+
+    const input = document.createElement('input');
+    input.value = orb.img.src;
+    input.onchange = () => { orb.img.src = input.value; if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage(); };
+
+    const labelInput = document.createElement('input');
+    labelInput.placeholder = 'Label';
+    labelInput.value = orb.label || '';
+    labelInput.oninput = () => { orb.label = labelInput.value; if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage(); };
+
+    const roleSelect = document.createElement('select');
+    ['none', 'mod', 'lurker', 'passerby'].forEach(role => {
+      const option = document.createElement('option');
+      option.value = role;
+      option.textContent = role.charAt(0).toUpperCase() + role.slice(1);
+      if (orb.role === role) option.selected = true;
+      roleSelect.appendChild(option);
+    });
+    roleSelect.onchange = () => { orb.role = roleSelect.value; if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage(); };
+
+    const iconInput = document.createElement('input');
+    iconInput.placeholder = 'Icon';
+    iconInput.value = orb.roleIcon || '';
+    iconInput.oninput = () => { orb.roleIcon = iconInput.value; if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage(); };
+
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.value = orb.ringColor || '#ffffff';
+    colorInput.oninput = () => { orb.ringColor = colorInput.value; if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage(); };
+
+    const widthInput = document.createElement('input');
+    widthInput.type = 'range';
+    widthInput.min = 1;
+    widthInput.max = 10;
+    widthInput.value = orb.ringWidth || 4;
+    widthInput.oninput = () => { orb.ringWidth = parseInt(widthInput.value); if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage(); };
+
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = '🗑 Remove';
+    removeBtn.onclick = () => {
+      orbs.splice(i, 1);
+      updateOrbList();
+      if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage();
+    };
+
+    container.appendChild(input);
+    container.appendChild(labelInput);
+    container.appendChild(roleSelect);
+    container.appendChild(iconInput);
+    container.appendChild(colorInput);
+    container.appendChild(widthInput);
+    container.appendChild(removeBtn);
+    orbList.appendChild(container);
+  });
+}
+
+function saveOrbs() {
+  const saved = orbs.map(o => ({
+    src: o.img.src,
+    entryType: o.entryType,
+    role: o.role,
+    label: o.label,
+    ringColor: o.ringColor,
+    ringWidth: o.ringWidth,
+    roleIcon: o.roleIcon
+  }));
+  localStorage.setItem('savedOrbs', JSON.stringify(saved));
+}
+
+function loadOrbs() {
+  const data = JSON.parse(localStorage.getItem('savedOrbs') || '[]');
+  orbs.length = 0;
+  data.forEach(o => {
+    addOrb(o.src, o.entryType, o.role, o.label, o.ringColor, o.ringWidth, o.roleIcon);
+  });
+  if (typeof updateOrbList === 'function') updateOrbList();
+  if (typeof window.sendOrbsToStage === 'function') window.sendOrbsToStage();
 }
 
 function drawRoundedImage(img, x, y, size) {

--- a/stage.html
+++ b/stage.html
@@ -20,5 +20,11 @@
 <body>
   <canvas id="bouncerCanvas" width="405" height="720"></canvas>
   <script src="shared.js"></script>
+  <script>
+    // Ask any open admin page for the current orb setup
+    if (typeof requestOrbSync === 'function') {
+      requestOrbSync();
+    }
+  </script>
 </body>
 </html>

--- a/test/orb-sync.test.js
+++ b/test/orb-sync.test.js
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const { BroadcastChannel } = require('node:worker_threads');
+
+function createEnv(url, hasCanvas) {
+  const document = {
+    elements: {},
+    getElementById(id) { return this.elements[id] || null; },
+    createElement(tag) { return { tagName: tag, style: {}, appendChild() {}, setAttribute() {}, oninput: null, onchange: null, onclick: null }; },
+    get defaultView() { return window; }
+  };
+  const canvas = hasCanvas ? {
+    width: 300,
+    height: 300,
+    style: {},
+    getContext() {
+      return {
+        clearRect() {}, save() {}, beginPath() {}, arc() {}, closePath() {}, clip() {}, drawImage() {}, restore() {}, stroke() {}, fillText() {}, strokeStyle: '', lineWidth: 0, font: '', textAlign: '', fillStyle: ''
+      };
+    }
+  } : null;
+  if (hasCanvas) document.elements['bouncerCanvas'] = canvas;
+  const window = {
+    document,
+    location: { href: url },
+    requestAnimationFrame: () => {},
+    Image: class { constructor() { this.src = ''; } },
+    BroadcastChannel,
+    localStorage: {
+      store: {},
+      getItem(k) { return this.store[k] || null; },
+      setItem(k, v) { this.store[k] = String(v); },
+      removeItem(k) { delete this.store[k]; }
+    }
+  };
+  window.window = window;
+  const context = { window, document, location: window.location, console, BroadcastChannel, Image: window.Image, localStorage: window.localStorage, requestAnimationFrame: window.requestAnimationFrame };
+  return { context, window };
+}
+
+const sharedCode = fs.readFileSync(require('node:path').join(__dirname, '..', 'shared.js'), 'utf8');
+
+function runShared(env) {
+  vm.runInNewContext(sharedCode, env.context);
+}
+
+function wait(ms = 20) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+test('stage can request sync from admin', async () => {
+  const admin = createEnv('https://example.com/admin.html', false);
+  runShared(admin);
+  admin.context.addOrb('sync.png');
+
+  const stage = createEnv('https://example.com/stage.html', true);
+  runShared(stage);
+
+  stage.context.window.requestOrbSync();
+  await wait();
+  assert.equal(stage.context.window.orbs.length, 1);
+  assert.equal(stage.context.window.orbs[0].img.src, 'sync.png');
+  admin.window.channel.close();
+  stage.window.channel.close();
+});
+
+test('admin updates propagate to stage', async () => {
+  const admin = createEnv('https://example.com/admin.html', false);
+  runShared(admin);
+
+  const stage = createEnv('https://example.com/stage.html', true);
+  runShared(stage);
+
+  admin.context.addOrb('live.png');
+  await wait();
+  assert.equal(stage.context.window.orbs.length, 1);
+  assert.equal(stage.context.window.orbs[0].img.src, 'live.png');
+  admin.window.channel.close();
+  stage.window.channel.close();
+});


### PR DESCRIPTION
## Summary
- expose `orbs` and `channel` on the `window` so tests and other scripts can inspect or close them
- allow `addOrb` to add items even when no canvas is present and notify stage via `sendOrbsToStage`
- add automation tests verifying the stage can request initial sync and receives updates when admin orbs change

## Testing
- `node --check shared.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891d8891310832c845575e0f7997866